### PR TITLE
properly support all locales #1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: perl
 perl:
     - "blead"
+    - "5.30"
+    - "5.28"
     - "5.26"
     - "5.24"
     - "5.22"
@@ -12,10 +14,17 @@ perl:
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --auto
 
+addons:
+  apt:
+    packages:
+      - language-pack-de
+
 matrix:
   include:
     - perl: 5.18
       env: COVERAGE=1 # enables coverage+coveralls reporting
+    - perl: 5.28
+      env: LC_ALL=de_DE.UTF-8
   allow_failures:
     - perl: blead     # ignores failures for blead perl
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Dancer2-Logger-Console-Colored
 
 {{$NEXT}}
+	- GH #1: Fix encoding problems with some locales
+	- Add blog post to documentation
 
 0.006     2017-10-13 18:11:06+02:00 Europe/Berlin
 	- Rerelease the previous version because it was broken.

--- a/lib/Dancer2/Logger/Console/Colored.pm
+++ b/lib/Dancer2/Logger/Console/Colored.pm
@@ -107,10 +107,7 @@ sub format_message {
   my $block_handler = sub {
     my ( $block, $type ) = @_;
     if ( $type eq 't' ) {
-      return Encode::decode(
-        $config->{'charset'} || 'UTF-8',
-        POSIX::strftime( $block, localtime(time) )
-      );
+        POSIX::strftime( $block, localtime(time) );
     }
     elsif ( $type eq 'h' ) {
       return ( $request && $request->header($block) ) || '-';
@@ -124,18 +121,10 @@ sub format_message {
   my $chars_mapping = {
     a => sub { $self->colorize_origin( $self->app_name ) },
     t => sub {
-      Encode::decode(
-        $config->{'charset'} || 'UTF-8',
-        POSIX::strftime( "%d/%b/%Y %H:%M:%S", localtime(time) )
-      );
+        POSIX::strftime( "%d/%b/%Y %H:%M:%S", localtime(time) );
     },
     T => sub { POSIX::strftime( "%Y-%m-%d %H:%M:%S", localtime(time) ) },
-    u => sub {
-      Encode::decode(
-        $config->{'charset'} || 'UTF-8',
-        POSIX::strftime( "%d/%b/%Y %H:%M:%S", gmtime(time) )
-      );
-    },
+    u => sub { POSIX::strftime( "%d/%b/%Y %H:%M:%S", gmtime(time) ) },
     U => sub { POSIX::strftime( "%Y-%m-%d %H:%M:%S", gmtime(time) ) },
     P => sub { $$ },
     L => sub { $self->colorize_level($level) },


### PR DESCRIPTION
We also try to run tests on a locale that is known to fail.
See https://github.com/PerlDancer/Dancer2/pull/1499, where this has been more widely fixed in Dancer2, for more details.

Closes #1 